### PR TITLE
Add the ability to limit amount of requests from ip range

### DIFF
--- a/httpmw/limit_test.go
+++ b/httpmw/limit_test.go
@@ -11,13 +11,14 @@ import (
 )
 
 const limitTestURL = "/some-url"
+const limitTestIPRanges = "192.168.10.1-192.168.10.10,192.168.20.1-192.168.20.10"
 const limitTestCount = 3
 
-func createLimitServer(limits int) http.Handler {
+func createLimitServer(limits int, ipRanges string) http.Handler {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	router.Use(Limit(limits))
+	router.Use(Limit(limits, ipRanges))
 	router.GET(limitTestURL, func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
@@ -27,17 +28,49 @@ func createLimitServer(limits int) http.Handler {
 
 func TestLimit(t *testing.T) {
 	assert := assert.New(t)
-	srv := httptest.NewServer(createLimitServer(limitTestCount))
-	defer srv.Close()
 
-	for i := 0; i < limitTestCount+1; i++ {
-		res, err := http.Get(fmt.Sprintf("%s%s", srv.URL, limitTestURL))
-		assert.NoError(err)
+	t.Run("without IP restriction", func(t *testing.T) {
+		srv := httptest.NewServer(createLimitServer(limitTestCount, ""))
+		defer srv.Close()
 
-		if i < limitTestCount {
-			assert.Equal(http.StatusOK, res.StatusCode)
-		} else {
-			assert.Equal(http.StatusTooManyRequests, res.StatusCode)
+		for i := 0; i < limitTestCount+1; i++ {
+			res, err := http.Get(fmt.Sprintf("%s%s", srv.URL, limitTestURL))
+			assert.NoError(err)
+
+			if i < limitTestCount {
+				assert.Equal(http.StatusOK, res.StatusCode)
+			} else {
+				assert.Equal(http.StatusTooManyRequests, res.StatusCode)
+			}
 		}
-	}
+	})
+
+	t.Run("with IP restriction", func(t *testing.T) {
+		srv := httptest.NewServer(createLimitServer(limitTestCount, limitTestIPRanges))
+		defer srv.Close()
+
+		for i := 0; i < limitTestCount+1; i++ {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", srv.URL, limitTestURL), nil)
+			assert.NoError(err)
+			req.Header.Add("X-Forwarded-For", "192.168.10.2")
+
+			res, err := http.DefaultClient.Do(req)
+			assert.NoError(err)
+
+			if i < limitTestCount {
+				assert.Equal(http.StatusOK, res.StatusCode)
+			} else {
+				assert.Equal(http.StatusTooManyRequests, res.StatusCode)
+			}
+		}
+
+		for i := 0; i < limitTestCount+100; i++ {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", srv.URL, limitTestURL), nil)
+			assert.NoError(err)
+
+			res, err := http.DefaultClient.Do(req)
+			assert.NoError(err)
+			assert.Equal(http.StatusOK, res.StatusCode)
+		}
+	})
 }


### PR DESCRIPTION
Main point of this is to add optional parameter to limit middleware that will allow us to limit the amount of requests from IP ranges.