### PR TITLE
Added custom Log Formatter

### DIFF
--- a/httpmw/logging.go
+++ b/httpmw/logging.go
@@ -1,0 +1,51 @@
+package httpmw
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type logEntry struct {
+	RequestTime string   `json:"request_time"`
+	Ip          string   `json:"ip"`
+	Path        string   `json:"path"`
+	Status      int      `json:"status"`
+	Username    string   `json:"username"`
+	UserGroups  []string `json:"user_groups"`
+}
+
+// LogFormatter builds a logging entry in JSON format containing these fields:
+// - Unix timestamp of the request time
+// - Client's IP address
+// - Accessed API endpoint/path
+// - Request's response status code
+//
+// This function will also look into the gin's context for a user instance.
+// If a CognitoUser instance is found, the formatter will also include the following fields:
+// - Username
+// - User associated group(s)
+func LogFormatter(params gin.LogFormatterParams) string {
+	var user *CognitoUser
+
+	entry := &logEntry{
+		RequestTime: params.TimeStamp.Format(time.RFC3339),
+		Ip:          params.ClientIP,
+		Path:        params.Path,
+		Status:      params.StatusCode,
+	}
+
+	if val, ok := params.Keys["user"]; ok && val != nil {
+		user, _ = val.(*CognitoUser)
+	}
+
+	if user != nil {
+		entry.Username = user.Username
+		entry.UserGroups = user.GetGroups()
+	}
+
+	b, _ := json.Marshal(entry)
+	return fmt.Sprintln(string(b))
+}

--- a/httpmw/logging_test.go
+++ b/httpmw/logging_test.go
@@ -1,0 +1,92 @@
+package httpmw
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogFormatter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	assert := assert.New(t)
+
+	t.Run("test log formatting function", func(_ *testing.T) {
+		t.Run("test without cognito user middleware", func(_ *testing.T) {
+			e := gin.New()
+			out := new(bytes.Buffer)
+			apiPath := "/test"
+			testIP := "0.0.0.0"
+
+			e.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+				Formatter: LogFormatter,
+				Output:    out,
+			}))
+
+			e.GET(apiPath, func(c *gin.Context) {
+				c.Status(http.StatusTeapot)
+			})
+
+			req, err := http.NewRequest(http.MethodGet, apiPath, nil)
+			assert.NoError(err)
+			req.Header.Add("X-Forwarded-For", testIP)
+
+			w := httptest.NewRecorder()
+			e.ServeHTTP(w, req)
+			assert.Equal(http.StatusTeapot, w.Code)
+
+			entry := new(logEntry)
+			err = json.Unmarshal(out.Bytes(), entry)
+			assert.NoError(err)
+
+			assert.NotEmpty(entry.RequestTime)
+			assert.Equal(testIP, entry.Ip)
+			assert.Equal(apiPath, entry.Path)
+			assert.Equal(w.Code, entry.Status)
+		})
+	})
+
+	t.Run("test with cognito user middleware", func(_ *testing.T) {
+		e := gin.New()
+		out := new(bytes.Buffer)
+		apiPath := "/test"
+		testIP := "0.0.0.0"
+
+		testUser := &CognitoUser{
+			Username: "test_username",
+			Groups:   []string{"group_1"},
+		}
+
+		e.Use(func(c *gin.Context) {
+			c.Set("user", testUser)
+		})
+
+		e.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+			Formatter: LogFormatter,
+			Output:    out,
+		}))
+
+		e.GET(apiPath, func(c *gin.Context) {
+			c.Status(http.StatusTeapot)
+		})
+
+		req, err := http.NewRequest(http.MethodGet, apiPath, nil)
+		assert.NoError(err)
+		req.Header.Add("X-Forwarded-For", testIP)
+
+		w := httptest.NewRecorder()
+		e.ServeHTTP(w, req)
+		assert.Equal(http.StatusTeapot, w.Code)
+
+		entry := new(logEntry)
+		err = json.Unmarshal(out.Bytes(), entry)
+		assert.NoError(err)
+
+		assert.Equal(testUser.Username, entry.Username)
+		assert.ElementsMatch(testUser.Groups, entry.UserGroups)
+	})
+}


### PR DESCRIPTION
Added custom log formatter for gin logging middleware.

This formatter will create a log entry in JSON format with the following information:

- Request's timestamp in RFC3339 format
- Client's IP address
- Consumed API path/endpoint
- Request's response status code

It will also include the following fields if a `CognitoCache` instance
is in the gin's context:

- Username
- User's groups

---

Simple usage example:

```go
package main

import (
	"net/http"

	"github.com/gin-gonic/gin"
	"github.com/protsack-stephan/gin-toolkit/httpmw"
)

func main() {
	g := gin.New()
	g.Use(gin.Recovery())
	g.Use(gin.LoggerWithFormatter(httpmw.LogFormatter))

	g.GET("/", func(c *gin.Context) {
		c.Status(http.StatusTeapot)
	})

	g.Run()
}
```

Produced output:

```js
{"request_time":"2022-05-05T12:46:21-05:00","ip":"::1","path":"/","status":418,"username":"","user_groups":null}
```

Note `username` and `user_groups` are empty due to missing `CognitoCache` user in gin's context